### PR TITLE
Improve CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,8 +3,8 @@ name: Lint
 
 on:
   push:
-    branches-ignore:
-      - 'docs'
+    paths-ignore:
+      - 'src/theme-src/**'
 
 jobs:
   lint:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,7 @@ MASTER
 
 - feat: new option to make autodocs definitions collapsible (PR #167)
 - fix: accessibility for collapsible (PR #174)
+- fix: rounded search input on iOS (PR #181)
 
 1.15.1
 ~~~~~~


### PR DESCRIPTION
Exclude the `./src/theme-src/` directory from triggering the `lint` action. 