### PR TITLE
fix: missing implementation for headerlinks (#193)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ MASTER
 - fix: rounded search input on iOS (PR #181)
 - fix: add styles for blockquotes (PR #192)
 - fix: inconsistent padding in header with and without logo (PR #188)
+- fix: implementation for headerlinks (PR #194)
 
 1.15.1
 ~~~~~~

--- a/src/sphinxawesome_theme/html_translator.py
+++ b/src/sphinxawesome_theme/html_translator.py
@@ -66,10 +66,20 @@ class AwesomeHTMLTranslator(HTML5Translator):
             and node.parent.hasattr("ids")
             and node.parent["ids"]
         ):
-            # add permalink anchor
+            # add permalink anchor to normal headings
             if close_tag.startswith("</h"):
                 self.add_permalink_ref(
                     node.parent, _(f"Copy link to section: {node.astext()}.")
+                )
+            # and to headings when the 'contents' directive is used
+            elif close_tag.startswith("</a></h"):
+                self.body.append(
+                    "</a><a role='button' "
+                    "class='headerlink tooltipped tooltipped-ne' "
+                    'href="#{}" '
+                    'aria-label="Copy link to this section: {}">'.format(
+                        node["ids"][0], node.astext()
+                    )
                 )
             elif isinstance(node.parent, nodes.table):
                 self.body.append("</span>")


### PR DESCRIPTION
It turns out that if you use the docutils contents directive,
the headings are differently structured (`<h1><a>Heading</a></h1>`).
This was being handled upstream just fine, I just missed this branch
in the `depart_title` method because I didn't understand what it was
for.