### PR TITLE
fix: prevent empty copyright (#285)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,9 @@
+MASTER
+~~~~~~
+
+- fix: prevent printing empty copyright (#285)
+
+
 1.18.0
 ~~~~~~
 

--- a/src/sphinxawesome_theme/footer.html
+++ b/src/sphinxawesome_theme/footer.html
@@ -6,7 +6,7 @@
   role="contentinfo"
   class="mt-20 px-5 md:ml-fluid mb-4 flex-shrink-0 text-sm text-gray-700 {% if not theme_show_nav -%}mx-auto{%- endif -%}"
 >
-{%- if show_copyright -%}
+{%- if show_copyright and copyright|length -%}
   {%- if hasdoc('copyright') -%}
     {%- trans path=pathto('copyright'), copyright=copyright|e -%}
       &copy; <a href="{{ path }}">Copyright</a>{{ copyright }}

--- a/tests/roots/test-copyright/conf.py
+++ b/tests/roots/test-copyright/conf.py
@@ -1,0 +1,7 @@
+"""Basic Sphinx configuration file for testing.
+
+We use ``confoverrides`` in the tests to provide
+the actual configuration.
+"""
+
+html_theme = "sphinxawesome_theme"

--- a/tests/roots/test-copyright/index.rst
+++ b/tests/roots/test-copyright/index.rst
@@ -1,0 +1,5 @@
+Test
+====
+
+The content of this file is not important.
+For this test, we only check the footer.

--- a/tests/test_copyright.py
+++ b/tests/test_copyright.py
@@ -1,0 +1,72 @@
+"""Tests for copyright info.
+
+When the `copyright` setting is empty,
+no copyright info should be printed.
+
+Issue #285.
+"""
+import re
+
+from bs4 import BeautifulSoup
+import pytest
+from sphinx.application import Sphinx
+
+
+def parse_html(filename: str) -> BeautifulSoup:
+    """Parse an HTML file into a BeautifulSoup tree."""
+    with open(filename) as file_handle:
+        tree = BeautifulSoup(file_handle, "html.parser")
+    return tree
+
+
+@pytest.mark.sphinx(
+    "html",
+    testroot="copyright",
+)
+def test_empty_copyright_info(app: Sphinx) -> None:
+    """It does not contain any Copyright info in the footer."""
+    app.build()
+    tree = parse_html(app.outdir / "index.html")
+    footer = tree("footer", role="contentinfo")
+    assert len(footer) == 1
+
+    # search for text in the children of footer
+    for child in footer:
+        matches = child.find_all(text=re.compile("Copyright"))
+        assert len(matches) == 0
+
+
+@pytest.mark.sphinx(
+    "html",
+    testroot="copyright",
+    confoverrides={"show_copyright": "False"},
+)
+def test_dont_show_copyright(app: Sphinx) -> None:
+    """It contains any Copyright info in the footer."""
+    app.build()
+    tree = parse_html(app.outdir / "index.html")
+    footer = tree("footer", role="contentinfo")
+    assert len(footer) == 1
+
+    # search for text in the children of footer
+    for child in footer:
+        matches = child.find_all(text=re.compile("Copyright"))
+        assert len(matches) == 0
+
+
+@pytest.mark.sphinx(
+    "html",
+    testroot="copyright",
+    confoverrides={"copyright": "Test"},
+)
+def test_show_copyright(app: Sphinx) -> None:
+    """It contains any Copyright info in the footer."""
+    app.build()
+    tree = parse_html(app.outdir / "index.html")
+    footer = tree("footer", role="contentinfo")
+    assert len(footer) == 1
+
+    # search for text in the children of footer
+    for child in footer:
+        matches = child.find_all(text=re.compile("Copyright"))
+        assert len(matches) == 1


### PR DESCRIPTION
Don't print the 'copyright' line, if the `copyright` variable is empty. 