### PR TITLE
chore: better dependency management

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,4 +27,4 @@ sphinxcontrib-qthelp==1.0.3; python_full_version >= "3.6.1" and python_full_vers
 sphinxcontrib-serializinghtml==1.1.5; python_full_version >= "3.6.1" and python_full_version < "4.0.0" and python_version >= "3.6"
 urllib3==1.26.6; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version < "4" and python_version >= "3.6"
 zipp==3.5.0; python_full_version >= "3.6.1" and python_version < "3.8" and python_full_version < "4.0.0" and python_version >= "3.6"
-myst-parser==0.15.0
+myst-parser==0.15.1; python_version >= "3.6"


### PR DESCRIPTION
Allow exporting of optional dev dependencies for netlify.

This is a hack for the following use case: For building the docs, I need `myst-parser`, but the theme itself isn't dependent on this package. On the other hand, I don't want to install the full set of development dependencies, _just_ for building the docs. 

This should get addressed by Poetry 1.2.

Closes #504 