### PR TITLE
chore: separete linkcheck action

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -1,0 +1,26 @@
+---
+name: Check Links
+
+on:
+  pull_request:
+    paths:
+      - './docs/**'
+      - 'README.md'
+
+jobs:
+  linkcheck:
+    runs-on: ubuntu-latest
+    name: Check links
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+      - name: Install dependencies
+        run: |
+          pip install --constraint=.github/workflows/constraints.txt poetry nox
+      - name: Run nox workflow
+        run: |
+          nox -s linkcheck

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,6 +28,3 @@ jobs:
       - name: Run nox workflow
         run: |
           nox -p ${{ matrix.python-version }}
-      - name: Run linkcheck session
-        run: |
-          nox -s linkcheck


### PR DESCRIPTION
The link check action is now only run when there are changes to the
documentation.

I also used an `enum` to handle the supported Python versions better.