### PR TITLE
fix: JSON serializer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ show_error_codes = true
 pretty = true
 
 [[tool.mypy.overrides]]
-module = ["pygments.*", "bs4"]
+module = ["pygments.*", "bs4", "sphinxcontrib.serializinghtml"]
 ignore_missing_imports = true
 
 [tool.poetry.plugins."sphinx.html_themes"]

--- a/src/sphinxawesome_theme/__init__.py
+++ b/src/sphinxawesome_theme/__init__.py
@@ -16,6 +16,9 @@ from os import path
 from typing import Any, Dict
 
 from sphinx.application import Sphinx
+from sphinxcontrib.serializinghtml import JSONHTMLBuilder
+
+from . import jsonimpl
 
 try:
     # obtain version from `pyproject.toml` via `importlib.metadata.version()`
@@ -31,6 +34,10 @@ def setup(app: "Sphinx") -> Dict[str, Any]:
     app.add_config_value("html_awesome_html_translator", True, "html")
     app.setup_extension("sphinxawesome_theme.highlighting")
     app.setup_extension("sphinxawesome_theme.jinja_functions")
+
+    JSONHTMLBuilder.out_suffix = ".json"
+    JSONHTMLBuilder.implementation = jsonimpl
+    JSONHTMLBuilder.indexer_format = jsonimpl
 
     if app.config.html_awesome_html_translator:
         app.setup_extension("sphinxawesome_theme.html_translator")

--- a/src/sphinxawesome_theme/jsonimpl.py
+++ b/src/sphinxawesome_theme/jsonimpl.py
@@ -1,0 +1,44 @@
+"""Custom JSON serializer.
+
+The awesome theme uses custom jinja2 helper functions which are
+non-serializable by default. Hence, I need to use a custom JSON
+serializer.
+
+:copyright: Copyright Kai Welke.
+:license: MIT, see LICENSE_ for details.
+
+.. _LICENSE: https://github.com/kai687/sphinxawesome-theme/blob/master/LICENSE
+"""
+
+import json
+from typing import IO, Any
+
+
+class AwesomeJSONEncoder(json.JSONEncoder):
+    """Custom JSON encoder for everything in the `context`."""
+
+    def default(self, obj: Any) -> str:
+        """Return an empty string for anything that's not serializable by default."""
+        return ""
+
+
+def dump(obj: Any, fp: IO[str], *args: Any, **kwargs: Any) -> None:
+    """Dump JSON into file."""
+    kwargs["cls"] = AwesomeJSONEncoder
+    return json.dump(obj, fp, *args, **kwargs)
+
+
+def dumps(obj: Any, *args: Any, **kwargs: Any) -> str:
+    """Convert object to JSON string."""
+    kwargs["cls"] = AwesomeJSONEncoder
+    return json.dumps(obj, *args, **kwargs)
+
+
+def load(*args: Any, **kwargs: Any) -> Any:
+    """De-serialize JSON."""
+    return json.load(*args, **kwargs)
+
+
+def loads(*args: Any, **kwargs: Any) -> Any:
+    """De-serialize JSON."""
+    return json.loads(*args, **kwargs)


### PR DESCRIPTION
When using `sphinx-build -b json`, the docs now build correctly.
Because I pass functions and partials into the `context`, I need
to have a custom JSON encoder.