### PR TITLE
docs: add meta descriptions

### DIFF
--- a/docs/about.md
+++ b/docs/about.md
@@ -1,6 +1,8 @@
 ---
 orphan: true
 layout: "without-sidebar"
+html_meta:
+  description: The Awesome Sphinx Theme is built on top of open-source assets. Click to learn more.
 ---
 
 (sec:about)=

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,11 +28,6 @@ extensions = [
 ]
 
 myst_enable_extensions = ["colon_fence", "deflist", "replacements", "substitution"]
-myst_substitutions = {
-    "title": project,
-    "description": "Create beautiful and modern documentation websites with Sphinx.",
-}
-
 exclude_patterns = ["public"]
 
 nitpicky = True

--- a/docs/demo/auto.rst
+++ b/docs/demo/auto.rst
@@ -1,3 +1,7 @@
+.. meta::
+   :description: See an example how module documentation looks like with this theme. Sphinx generates module documentation from docstrings in the source code.
+
+
 ====================
 Module documentation
 ====================

--- a/docs/demo/code-blocks.rst
+++ b/docs/demo/code-blocks.rst
@@ -1,3 +1,6 @@
+.. meta::
+   :description: See how code blocks look like with this theme and discover the awesome enhancements.
+
 .. role:: rst(code)
    :language: rst
    :class: highlight

--- a/docs/demo/contents.rst
+++ b/docs/demo/contents.rst
@@ -1,3 +1,6 @@
+.. meta::
+   :description: See how on-page navigation looks like in this theme.
+
 On-page navigation
 ==================
 

--- a/docs/demo/figures.rst
+++ b/docs/demo/figures.rst
@@ -1,3 +1,6 @@
+.. meta::
+   :description: Discover how the theme styles figures, images and their supporting elements, such as captions.
+
 Figures and tables
 ==================
 

--- a/docs/demo/inline-code.rst
+++ b/docs/demo/inline-code.rst
@@ -1,3 +1,6 @@
+.. meta::
+   :description: Learn how you can mark up inline code in Sphinx and see how it would look like on your website.
+
 .. role:: rst(code)
    :language: rst
    :class: highlight

--- a/docs/demo/lists.rst
+++ b/docs/demo/lists.rst
@@ -1,3 +1,6 @@
+.. meta::
+   :description: See how different lists look like in this theme. Discover the styles for ordered lists, unordered lists, and description lists.
+
 =====
 Lists
 =====

--- a/docs/demo/notes.rst
+++ b/docs/demo/notes.rst
@@ -1,3 +1,6 @@
+.. meta::
+   :description: Notes and warnings allow you to draw attention to issues or provide extra information. See how they look like with this theme.
+
 Notes, warnings, and quotations
 ===============================
 

--- a/docs/demo/text.rst
+++ b/docs/demo/text.rst
@@ -1,3 +1,6 @@
+.. meta::
+   :description: Textual elements like paragraphs and headings are essential parts of any documentation. Find out how they look like in this theme.
+
 Headings and text
 =================
 

--- a/docs/how-to/customize.md
+++ b/docs/how-to/customize.md
@@ -1,3 +1,10 @@
+---
+html_meta:
+  description: |
+    Adapt the theme to your needs by adding custom styles,
+    using custom layouts, or changing the default templates.
+---
+
 (sec:customize)=
 
 # Customize the theme

--- a/docs/how-to/install.md
+++ b/docs/how-to/install.md
@@ -1,3 +1,9 @@
+---
+html_theme:
+  description: |
+    Learn the different methods to install the theme, depending on your use case.
+---
+
 (sec:install)=
 
 # Install the theme

--- a/docs/how-to/load.md
+++ b/docs/how-to/load.md
@@ -1,3 +1,9 @@
+---
+html_theme:
+  description: |
+    Learn about the different ways to add the theme to your Sphinx project.
+---
+
 (sec:load)=
 
 # Load the theme

--- a/docs/how-to/modify.md
+++ b/docs/how-to/modify.md
@@ -1,3 +1,10 @@
+---
+html_theme:
+  description: |
+    Make your own theme by building on top of this theme.
+    Fully customize the styles, JavaScript, and templates.
+---
+
 (sec:modify)=
 
 # Modify the theme
@@ -15,9 +22,7 @@ backlinks: none
 
 ## Modify the templates
 
-You can
-
-Styles in the templates are applied via Tailwind's utility classes.
+You can apply styles in the templates with Tailwind's utility classes.
 
 ```{code-block} shell
 ---

--- a/docs/how-to/options.md
+++ b/docs/how-to/options.md
@@ -34,6 +34,8 @@ Sphinx configuration file `conf.py`.
 
 :::{confval} nav_include_hidden
 
+<!-- vale Awesome.SpellCheck = NO -->
+
 By default, the
 {sphinxdocs}`toctree <usage/restructuredtext/directives.html#directive-toctree>`
 directive includes the content and prints a list of links in the content area. A
@@ -41,6 +43,8 @@ directive includes the content and prints a list of links in the content area. A
 the list of links in the content area. This can be useful if navigation links are
 elsewhere on the page. Printing the same list of links in the content area would be
 redundant.
+
+<!-- vale Awesome.SpellCheck = YES -->
 
 If you don't want to include elements from a _hidden_ toctree directive in the
 navigation menu on the left, set:

--- a/docs/how-to/options.md
+++ b/docs/how-to/options.md
@@ -1,3 +1,9 @@
+---
+html_meta:
+  description: |
+    Configure the theme by changing an option in your Sphinx configuration file.
+---
+
 (sec:configure)=
 
 # How to configure the theme
@@ -28,7 +34,7 @@ Sphinx configuration file `conf.py`.
 
 :::{confval} nav_include_hidden
 
-By default, theme
+By default, the
 {sphinxdocs}`toctree <usage/restructuredtext/directives.html#directive-toctree>`
 directive includes the content and prints a list of links in the content area. A
 `toctree` directive with the `:hidden:` option includes the content, but doesn't print

--- a/docs/how-to/update.md
+++ b/docs/how-to/update.md
@@ -1,3 +1,10 @@
+---
+html_meta:
+  description: |
+    Updating the Sphinx awesome theme is straightforward for most users.
+    Find out what you should consider when updating between major versions.
+---
+
 # Update the theme
 
 ```{rst-class} lead

--- a/docs/how-to/use.md
+++ b/docs/how-to/use.md
@@ -1,8 +1,15 @@
+---
+html_meta:
+  description: |
+    Learn how to add the theme to your Sphinx documentation,
+    how to configure the theme, and how to use its features.
+---
+
 # Use the theme
 
 ```{rst-class} lead
 Learn how to add the theme to your Sphinx documentation,
-how to change the theme's options, and how to use it's features.
+how to change the theme's options, and how to use its features.
 ```
 
 ```{toctree}

--- a/docs/how-to/using.md
+++ b/docs/how-to/using.md
@@ -1,3 +1,8 @@
+---
+html_meta:
+  description: Find out how to leverage the features of the theme to make your Sphinx documentation awesome
+---
+
 # Make your documentation awesome
 
 ```{rst-class} lead

--- a/docs/index.md
+++ b/docs/index.md
@@ -55,7 +55,7 @@ In the _how-to_ section, you can learn more about the different
 {ref}`sec:customize`.
 You can get an overview over all available styles in the _demo_ section.
 
-## Get in touch
+## Give feedback
 
 Is something broken or missing?
 Create a [GitHub issue](https://github.com/kai687/sphinxawesome-theme/issues/new).

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,18 +1,18 @@
 ---
-description: "{{ description }}"
-keywords: documentation, sphinx, python
-"og:title": "{{ title }}"
-"og:description": "{{ description }}"
+html_meta:
+  title: The Awesome Sphinx Theme
+  description: Create functional and beautiful websites for your documentation with Sphinx.
+  keywords: Documentation, Sphinx, Python
 ---
 
 <!-- vale Google.Headings = NO -->
 
-# {{ title }}
+# Awesome Sphinx Theme
 
 <!-- vale Google.Headings = YES -->
 
 ```{rst-class} lead
-{{ description }}
+Create functional and beautiful websites for your documentation with Sphinx.
 ```
 
 ---


### PR DESCRIPTION
This PR adds meta descriptions to every page via frontmatter (Markdown) or the `meta` directive (reStructuredText).