### PR TITLE
fix: meta check

### DIFF
--- a/src/sphinxawesome_theme/page.html
+++ b/src/sphinxawesome_theme/page.html
@@ -1,4 +1,4 @@
-{% if meta.layout %}
+{% if meta and meta.layout %}
   {%- extends meta.layout + ".html"|default("with-sidebar.html") -%}
 {% else %}
   {% if theme_show_nav|tobool %}


### PR DESCRIPTION
When meta is not defined, the template `page.html` broke. Closes #662 