### PR TITLE
Fix UnicodeError when postprocessing files on Windows

### DIFF
--- a/src/sphinxawesome_theme/postprocess.py
+++ b/src/sphinxawesome_theme/postprocess.py
@@ -144,7 +144,7 @@ def _modify_html(html_filename: str, app: Sphinx) -> None:
         _headerlinks(tree)
     _strip_comments(tree)
 
-    with open(html_filename, "w") as out_file:
+    with open(html_filename, "w", encoding="utf-8") as out_file:
         out_file.write(str(tree))
 
 


### PR DESCRIPTION
The same file contents were read as `utf-8`, but written with the default encoding.
On my machine, the default encoding in python programs is cp1252, which causes a UnicodeError if any generated pages include non-ANSI characters.