### PR TITLE
chore: bump version again

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sphinxawesome-theme"
-version = "3.2.2"
+version = "3.2.3"
 description = "An awesome theme for the Sphinx documentation generator"
 readme = "README.md"
 authors = ["Kai Welke <kai687@pm.me>"]

--- a/src/theme-src/package.json
+++ b/src/theme-src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sphinxawesome-theme",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "scripts": {
     "build": "NODE_ENV=production webpack",
     "dev": "NODE_ENV=development webpack --watch --progress",

--- a/tests/test_sphinxawesome_theme.py
+++ b/tests/test_sphinxawesome_theme.py
@@ -10,7 +10,7 @@ import sphinxawesome_theme
 
 def test_returns_version() -> None:
     """It has the correct version."""
-    assert sphinxawesome_theme.__version__ == "3.2.2"
+    assert sphinxawesome_theme.__version__ == "3.2.3"
 
 
 @pytest.mark.sphinx("dummy")


### PR DESCRIPTION
I messed up tagging the wrong Git commit as release and then pushing it out to PyPI.
3.2.2 is virtually the same as 3.2.1

This commit increases the version to 3.2.3, so that the git state and PyPI state will be the same. I should really automate the tagging and stuff.