### PR TITLE
fix: allow terminal session

### DIFF
--- a/docs/how-to/install.md
+++ b/docs/how-to/install.md
@@ -28,13 +28,13 @@ backlinks: none
 Install the latest **released version** from the Python Package Index
 [PyPI](https://pypi.org/project/sphinxawesome-theme/):
 
-```shell-session
+```terminal
 pip install sphinxawesome-theme
 ```
 
 You can also install the latest **development version**:
 
-```shell-session
+```terminal
 pip install git+https://github.com/kai687/sphinxawesome-theme.git
 ```
 
@@ -56,7 +56,7 @@ you can install the theme as a local Python package.
 1. {ref}`sec:fork-and-clone`.
 1. To install the local version of the theme in your project:
 
-   ```{code-block} shell-session
+   ```{code-block} terminal
    ---
    emphasize-text: "/path/to/sphinxawesome_theme"
    ---
@@ -99,7 +99,7 @@ To modify the theme, create a local copy:
 
    - If you forked the repository, enter:
 
-     ```{code-block} shell-session
+     ```{code-block} terminal
      ---
      emphasize-text: GITHUB_USERNAME
      ---
@@ -110,7 +110,7 @@ To modify the theme, create a local copy:
 
    - If you didn't fork the repository, clone the original repository:
 
-     ```shell-session
+     ```terminal
      git clone https://github.com/kai687/sphinxawesome-theme.git
      ```
 
@@ -140,13 +140,13 @@ Follow these steps to install the Python dependencies:
 
 1. Install Nox:
 
-   ```shell-session
+   ```terminal
    pip install --user --upgrade nox
    ```
 
 1. Install the Python dependencies:
 
-   ```shell-session
+   ```terminal
    poetry install
    ```
 
@@ -154,7 +154,7 @@ Follow these steps to install the Python dependencies:
 
 1. Optional: install and test the pre-commit hooks:
 
-   ```shell-session
+   ```terminal
    poetry run pre-commit install
    ```
 
@@ -163,7 +163,7 @@ Follow these steps to install the Python dependencies:
 
    To test pre-commit with Poetry, run:
 
-   ```shell-session
+   ```terminal
    poetry run pre-commit run --all
    ```
 
@@ -174,13 +174,13 @@ Follow these steps to install the Python dependencies:
    You can run any Nox session to confirm that the environment is working.
    To list the available sessions, enter:
 
-   ```shell-session
+   ```terminal
    nox -ls
    ```
 
    For example, to build the documentation with Python 3.10, enter:
 
-   ```shell-session
+   ```terminal
    nox -s docs -p 3.10
    ```
 
@@ -203,7 +203,7 @@ Follow these steps to install the Python dependencies:
 
 1. Optional: install [`yarn`](https://classic.yarnpkg.com/lang/en/):
 
-   ```shell-session
+   ```terminal
    npm install --global yarn
    ```
 
@@ -214,7 +214,7 @@ Follow these steps to install the Python dependencies:
 
 1. Go to the `theme-src/` directory:
 
-   ```{code-block} shell-session
+   ```{code-block} terminal
    ---
    emphasize-lines: 4
    ---
@@ -229,12 +229,12 @@ Follow these steps to install the Python dependencies:
 
 1. Install the JavaScript dependencies:
 
-   ```shell-session
+   ```terminal
    yarn install
    ```
 
 1. Build the theme:
 
-   ```shell-session
+   ```terminal
    yarn build
    ```

--- a/docs/how-to/load.md
+++ b/docs/how-to/load.md
@@ -42,7 +42,7 @@ When loading the theme from a local directory, you need to manage the dependenci
 yourself. This theme needs the `beautifulsoup` package to run. You can install it with
 `pip`:
 
-```shell-session
+```terminal
 pip install bs4
 ```
 
@@ -55,7 +55,7 @@ pip install bs4
 The following example assumes you have a Sphinx project with the following structure,
 and you want to load the theme from the `_themes/` folder.
 
-```{code-block} shell-session
+```{code-block} terminal
 ---
 emphasize-lines: 4
 ---
@@ -73,7 +73,7 @@ To load the theme from a local directory, follow these steps:
 1. Copy the directory `sphinxawesome-theme/src/sphinxawesome_theme/` into your
    Sphinx project:
 
-   ```shell-session
+   ```terminal
    cp -r sphinxawesome-theme/src/sphinxawesome_theme _themes/
    ```
 

--- a/docs/how-to/modify.md
+++ b/docs/how-to/modify.md
@@ -24,7 +24,7 @@ backlinks: none
 
 You can apply styles in the templates with Tailwind's utility classes.
 
-```{code-block} shell
+```{code-block} terminal
 ---
 emphasize-lines: 1
 ---
@@ -55,7 +55,7 @@ To modify these styles, follow these steps:
 
 1. Build the theme:
 
-   ```shell
+   ```terminal
    yarn build
    ```
 
@@ -64,7 +64,7 @@ To modify these styles, follow these steps:
 Everything that's part of the main content, including everything that's converted from
 reStructuredText to HTML is styled using Tailwind's `@apply` directive.
 
-```{code-block} shell
+```{code-block} terminal
 ---
 emphasize-lines: 3
 ---
@@ -86,6 +86,6 @@ To modify these styles, follow these steps:
 
 1. Build the theme:
 
-   ```shell
+   ```terminal
    yarn build
    ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,7 +21,7 @@ Create functional and beautiful websites for your documentation with Sphinx.
 
 1. Install the theme:
 
-   ```shell-session
+   ```terminal
    pip install sphinxawesome-theme
    ```
 

--- a/src/sphinxawesome_theme/highlighting.py
+++ b/src/sphinxawesome_theme/highlighting.py
@@ -17,10 +17,11 @@ from docutils.nodes import Node
 from docutils.parsers.rst import directives  # type: ignore[attr-defined]
 from docutils.statemachine import StringList
 from pygments.formatters import HtmlFormatter
+from pygments.lexers.shell import BashSessionLexer
 from pygments.util import get_list_opt
 from sphinx.application import Sphinx
 from sphinx.directives.code import CodeBlock, dedent_lines
-from sphinx.highlighting import PygmentsBridge
+from sphinx.highlighting import PygmentsBridge, lexers
 from sphinx.locale import __
 from sphinx.util import logging, parselinenos
 from sphinx.util.docutils import SphinxDirective
@@ -31,6 +32,19 @@ logger = logging.getLogger(__name__)
 
 # type alias
 TokenStream = Generator[Tuple[int, str], None, None]
+
+
+class TerminalLexer(BashSessionLexer):
+    """Convenience lexer for terminal sessions.
+
+    This allows using the `terminal` language code for interactive shell sessions.
+    This is an alternative to `shell-session` and `console`.
+    """
+
+    aliases = ["terminal"]
+
+
+lexers["terminal"] = TerminalLexer()
 
 
 def container_wrapper(

--- a/src/sphinxawesome_theme/highlighting.py
+++ b/src/sphinxawesome_theme/highlighting.py
@@ -21,7 +21,7 @@ from pygments.lexers.shell import BashSessionLexer
 from pygments.util import get_list_opt
 from sphinx.application import Sphinx
 from sphinx.directives.code import CodeBlock, dedent_lines
-from sphinx.highlighting import PygmentsBridge, lexers
+from sphinx.highlighting import PygmentsBridge
 from sphinx.locale import __
 from sphinx.util import logging, parselinenos
 from sphinx.util.docutils import SphinxDirective
@@ -42,9 +42,6 @@ class TerminalLexer(BashSessionLexer):
     """
 
     aliases = ["terminal"]
-
-
-lexers["terminal"] = TerminalLexer()
 
 
 def container_wrapper(
@@ -309,6 +306,8 @@ def setup(app: "Sphinx") -> Dict[str, Any]:
     """Set up this internal extension."""
     PygmentsBridge.html_formatter = AwesomeHtmlFormatter
     directives.register_directive("code-block", AwesomeCodeBlock)
+
+    app.add_lexer("terminal", TerminalLexer)
 
     return {
         "version": __version__,

--- a/src/sphinxawesome_theme/highlighting.py
+++ b/src/sphinxawesome_theme/highlighting.py
@@ -34,7 +34,7 @@ logger = logging.getLogger(__name__)
 TokenStream = Generator[Tuple[int, str], None, None]
 
 
-class TerminalLexer(BashSessionLexer):
+class TerminalLexer(BashSessionLexer):  # type: ignore
     """Convenience lexer for terminal sessions.
 
     This allows using the `terminal` language code for interactive shell sessions.

--- a/src/sphinxawesome_theme/html_translator.py
+++ b/src/sphinxawesome_theme/html_translator.py
@@ -187,20 +187,7 @@ class AwesomeHTMLTranslator(HTML5Translator):
                 self.body.append('<div class="code-wrapper" data-controller="code">\n')
 
                 code_header = "<div class='code-header'>\n"
-                lang_alias = {
-                    # Sphinx default highlighter is essentially Python
-                    "default": "python",
-                    # Shorter in headlines
-                    "shell-session": "shell",
-                    # Interactive PowerShell sessions
-                    "ps1con": "powershell",
-                }
-                if lang in lang_alias:
-                    code_lang = lang.replace(lang, lang_alias[lang])
-                else:
-                    code_lang = lang
-
-                code_header += f"<span class='code-lang'>{code_lang}</span>"
+                code_header += f"<span class='code-lang'>{lang}</span>"
                 code_header += "</div>\n"
                 self.body.append(code_header)
 


### PR DESCRIPTION
This PR adds a new `terminal` lexer to Sphinx, which allows me to use `terminal` as a highlighting language instead of `shell-session` or `console` which I never liked.

Until now, I had a dirty hack, where I just replaced some languages with other values when parsing. Adding a new lexer is much cleaner, as it doesn't change the default behavior. It just adds to it.