### PR TITLE
fix: bug when not using DocSearch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,66 +1,61 @@
-3.3.0
-~~~~
+# Changelog
+
+## HEAD
+
+- Handle DocSearch inclusion correctly (#781)
+
+## 3.3.0
 
 - Use normal font size for sidebar and TOC links
 - Smaller vertical padding for
 - Code blocks without shadow and smaller
 - Add the ability to add icons in extra_header_link
 
-3.2.3
-~~~~~
+## 3.2.3
 
 - Fix encoding issues on Windows (#720)
 
-3.2.2
-~~~~~
+## 3.2.2
 
 - Tagged the wrong commit, too lazy to fix.
 
-3.2.1
-~~~~~
+## 3.2.1
 
 - Fix footnote styles (#667)
 - Fix option list styles
 
-3.2.0
-~~~~~
+## 3.2.0
 
 - add styles for view code extension
 
-3.1.1
-~~~~~
+## 3.1.1
 
 - fix issue in page.html (#662)
 
-3.1.0
-~~~~~
+## 3.1.0
 
 - add DocSearch
 - bugfix when highlight_language is undefined
 - bugfix for canonical links when using the DirectoryBuilder
 
-3.0.0
-~~~~~
+## 3.0.0
 
 - asset hashing
 - feat: almost complete redesign
 - Solid JavaScript foundation based on Stimulus
 - Even better code blocks (support arbitrary emphasizing text inside code blocks; no
-  need for special ``samp`` directive)
+  need for special `samp` directive)
 
-2.0.2
-~~~~~
+## 2.0.2
 
 - fix: remove duplicate inclusion of style sheets
 
-2.0.1
-~~~~~
+## 2.0.1
 
 - fix: style issues (PR #500)
 - documentation update
 
-2.0.0
-~~~~~
+## 2.0.0
 
 **This version requires Sphinx >4.0**
 
@@ -72,27 +67,21 @@
 - fix: style for guilabel role was missing (#376)
 - fix: update for Sphinx 4.0/docutils 0.17
 
-1.19.2
-~~~~~~
+## 1.19.2
 
 - fix: permalink behavior for Sphinx 3.5 (#336)
 - chore: mypy configuration update
 
-1.19.1
-~~~~~~
+## 1.19.1
 
 - fix: search for 3.4.3 (#301)
 
-
-1.19.0
-~~~~~~
+## 1.19.0
 
 - fix: prevent printing empty copyright (#285)
 - feat: add styles for centered images (#283)
 
-
-1.18.0
-~~~~~~
+## 1.18.0
 
 - feat: add previous/next links (optional)
 - feat: add styles for 'diff' highlighting language (PR #230)
@@ -102,26 +91,20 @@
 - fix: skip to content link (#182)
 - chore: update Tailwind to 2.0
 
-
-1.17.0
-~~~~~~
+## 1.17.0
 
 - feat: add copy buttons to all literal blocks (#215)
 - fix: expand-more buttons systematically applied (PR #209)
 - fix: changed tag and filenames of footer and copyright (#202)
 - fix: inconsistent vertical spacing around blockquotes (#212)
 
-
-1.16.1
-~~~~~~
+## 1.16.1
 
 - fix: respect explicitly labeled admonitions (PR# 197)
 - fix: bug in headerlink mechanism (PR #199)
 - chore: increased test coverage (PR #201)
 
-
-1.16.0
-~~~~~~
+## 1.16.0
 
 - feat: new option to make autodocs definitions collapsible (PR #167)
 - fix: accessibility for collapsible (PR #174)
@@ -130,24 +113,18 @@
 - fix: inconsistent padding in header with and without logo (PR #188)
 - fix: implementation for headerlinks (PR #194)
 
-
-1.15.1
-~~~~~~
+## 1.15.1
 
 - fix: assign nav-link only once (#166)
 
-
-1.15.0
-~~~~~~
+## 1.15.0
 
 - feat: modified autodocs styling
 - feat: redesigned admonitions to not be in your face so much
 - fix: wrongly applied padding to logo on main page
 - feat: unrounded inputs, buttons, and blocks.
 
-
-1.14.0
-~~~~~~
+## 1.14.0
 
 - feat: switched to Material icons (#144)
 - feat: mark external links (#142)
@@ -160,149 +137,123 @@
 - fix: unwanted rounding of elements (#147)
 - fix: better navigation menu (#130)
 
-
-1.13.1
-~~~~~~
+## 1.13.1
 
 - fix: modified linenumber styling to work with new Sphinx (#123)
 
-
-1.13.0
-~~~~~~
+## 1.13.0
 
 - feat: better code-block directive with support for added/removed lines
 - fix: remove outline-none
 - docs: major update
 - chore: made JavaScript and CSS more modular
 
-
-1.12.1
-~~~~~~
+## 1.12.1
 
 - fix: wrong link title in skip to content link
 
-
-1.12.0
-~~~~~~
+## 1.12.0
 
 - fix: better autodoc styling
 - feat: add command line option styles
 - feat: better collapsible navigation (#102)
 - feat: skip to content link (#109)
 
-
-1.11.0
-~~~~~~
+## 1.11.0
 
 - fix: table caption number style (#96)
 - fix: iOS nav menu close button fix (#65)
 - feat: improve autodoc styling (#39)
 - docs: add autodoc example
 
-1.10.5
-~~~~~~
+## 1.10.5
 
 - fix: python extensions run only for HTML builders (#95)
 - chore: basic unit testing
 
-1.10.4
-~~~~~~
+## 1.10.4
 
 - fix: admonition ids were still problematic in LaTeX builds
 
-1.10.3
-~~~~~~
+## 1.10.3
 
 - fix: non-existing section titles no longer crash admonition_id
 
-1.10.2
-~~~~~~
+## 1.10.2
 
 - fix: non-existing image captions no longer crash HTML build (#93)
 
-1.10.1
-~~~~~~
+## 1.10.1
 
 - feat: make headerlinks accessible by keyboard (#91)
 - fix: let current navigation elements stay expanded when tabbing
 
-1.10.0
-~~~~~~
+## 1.10.0
 
 - feat: make navigation elements accessible by keyboard
 - feat: implement scrollspy for navigation (#70)
 - fix: remove background for non-current navigation elements (#72)
 - fix: list markers showing up in the search-results (#71)
 
-1.9.0
-~~~~~
+## 1.9.0
 
-- more semantic elements (``div.section`` -> ``section``, ``div.figure`` -> ``figure``, etc.)
+- more semantic elements (`div.section` -> `section`, `div.figure` -> `figure`, etc.)
 - feat: collapsible navigation links
 - chore: moved static DOM manipulation to new post-processing code in Python (#62)
 
-1.8.0
-~~~~~
+## 1.8.0
 
 - fix: improvements for search pane (#53)
 - feat: add permalinks to admonitions (#58)
 - fix: moved some permalink manipulation from JavaScript to Python
 - fix: migrate menu state transitions to data-attributes (#55)
 
-1.7.0
-~~~~~
+## 1.7.0
 
 - feat: added auto-enabling of sampdirective extension
 - feat: re-design
 
-1.6.3
-~~~~~
+## 1.6.3
 
 - fix: added styles for on-page TOC (#38)
 - fix: clicking on current page links closes nav menu (#42)
-- chore: moved to ``src`` package layout
+- chore: moved to `src` package layout
 - chore: added nox for automation control
 - chore: added Github actions for some linting
 - chore: added stylelint to lint CSS files
 - chore: added eslint for linting JavaScript
 - chore: added vale for simple style checks
 
-1.6.2
-~~~~~
+## 1.6.2
 
 - fix: title in menu pane also leads back to homepage (#36)
 - fix: improved search input on iOS (#1)
 - fix: improved search input width on wider screens
 
-1.6.1
-~~~~~
+## 1.6.1
 
 - fix(footer): justify-center
 - fix(footer): made sticky (again?) (#32)
 - fix(layout): improve layout on large screens (#31)
-- fix: replace '-' with '|' in <title> (#33)
+- fix: replace '-' with '|' in `<title>` (#33)
 
-1.6.0
-~~~~~
+## 1.6.0
 
 - fix: snackbar looks different for message vs. action (#30)
 - fix: added 'print:' media-query to tailwind config
 - feat: made permalinks more semantic
 - feat: added directive for highlighting placeholder variables (#15)
 
-1.5.0
-~~~~~
+## 1.5.0
 
 - feat: clicking on permalink copies the link to clipboard (#29)
 
-1.4.1
-~~~~~
+## 1.4.1
 
 - fix: make bold text medium (#28)
 - fix: improved padding in linenumber display
 
-1.4.0
-~~~~~
+## 1.4.0
 
 - fix: showing linenumbers for code blocks (#18)
 - fix: make copy button for literals stick (#22)
@@ -317,13 +268,11 @@
 - fix: removed dependency on Roboto semibold (#14)
 - docs: restructuring, adding more install instructions
 
-1.3.1
-~~~~~
+## 1.3.1
 
 - fix: include only used fonts (#12)
 
-1.3.0
-~~~~~
+## 1.3.0
 
 - feature: focus on search input when pressing '/' key
 - feature: add project title to HTML header
@@ -331,26 +280,22 @@
 - fix: make nav links normal (#4)
 - fix: made footer sticky (#6)
 
-1.2.0
-~~~~~
+## 1.2.0
 
 - Added styles for more admonitions
 - Added styles for "rubric" heading level and TOC captions
 - Fixed alignment bug for "copyright" info on small screens
 - Refactored docs
 
-1.1.0
-~~~~~
+## 1.1.0
 
 - Added translatable strings throughout the theme
 - Added option to override styles
 
-1.0.1
-~~~~~
+## 1.0.1
 
 - Added better labels to buttons
 
-1.0.0
-~~~~~
+## 1.0.0
 
 - Initial release

--- a/src/sphinxawesome_theme/__init__.py
+++ b/src/sphinxawesome_theme/__init__.py
@@ -28,10 +28,9 @@ except PackageNotFoundError:  # pragma: no cover
     __version__ = "unknown"
 
 
-def conditional_setup(app: Sphinx, config: Config) -> None:
+def post_config_setup(app: Sphinx, config: Config) -> None:
     """Set up extensions if configuration is ready."""
-    if config.html_awesome_docsearch:
-        app.setup_extension("sphinxawesome_theme.docsearch")
+    app.setup_extension("sphinxawesome_theme.docsearch")
 
     if config.html_awesome_html_translator:
         app.setup_extension("sphinxawesome_theme.html_translator")
@@ -69,8 +68,7 @@ def setup(app: "Sphinx") -> Dict[str, Any]:
 
     app.setup_extension("sphinxawesome_theme.highlighting")
     app.setup_extension("sphinxawesome_theme.jinja_functions")
-
-    app.connect("config-inited", conditional_setup)
+    app.connect("config-inited", post_config_setup)
 
     JSONHTMLBuilder.out_suffix = ".json"
     JSONHTMLBuilder.implementation = jsonimpl

--- a/src/sphinxawesome_theme/docsearch.py
+++ b/src/sphinxawesome_theme/docsearch.py
@@ -30,30 +30,37 @@ def setup_docsearch(
     Config can be provided via environment variables, a `.env.` file,
     or the Sphinx configuration file.
     """
-    # load `.env` file into environment
-    load_dotenv(dotenv_path=(Path(app.confdir) / ".env"))
-
-    docsearch_config = {
-        "container": (
-            os.getenv("DOCSEARCH_CONTAINER")
-            or app.config.docsearch_config.get("container", "#docsearch")
-        ),
-        "app_id": (
-            os.getenv("DOCSEARCH_APP_ID") or app.config.docsearch_config.get("app_id")
-        ),
-        "api_key": (
-            os.getenv("DOCSEARCH_API_KEY") or app.config.docsearch_config.get("api_key")
-        ),
-        "index_name": (
-            os.getenv("DOCSEARCH_INDEX_NAME")
-            or app.config.docsearch_config.get("index_name")
-        ),
-    }
-
-    # if we want to use `docsearch` we don't need any other JS file from Sphinx
     if app.config.html_awesome_docsearch:
+
+        # load `.env` file into environment
+        load_dotenv(dotenv_path=(Path(app.confdir) / ".env"))
+
+        docsearch_config = {
+            "container": (
+                os.getenv("DOCSEARCH_CONTAINER")
+                or app.config.docsearch_config.get("container", "#docsearch")
+            ),
+            "app_id": (
+                os.getenv("DOCSEARCH_APP_ID")
+                or app.config.docsearch_config.get("app_id")
+            ),
+            "api_key": (
+                os.getenv("DOCSEARCH_API_KEY")
+                or app.config.docsearch_config.get("api_key")
+            ),
+            "index_name": (
+                os.getenv("DOCSEARCH_INDEX_NAME")
+                or app.config.docsearch_config.get("index_name")
+            ),
+        }
+        # If we want to use `docsearch` we don't need any other JS file from Sphinx
         context["script_files"] = []
 
+    else:
+        # If we're not using DocSearch, set this to an empty Dict (default value)
+        docsearch_config = app.config.docsearch_config
+
+    # Even if we're not using DocSearch, these things MUST be in the context
     context["docsearch"] = app.config.html_awesome_docsearch
     # update local context for rendering the `layout.html` templates for every page
     context["docsearch_config"] = docsearch_config
@@ -63,7 +70,9 @@ def setup_docsearch(
 
 def setup(app: Sphinx) -> Dict[str, Any]:
     """Register the extension."""
-    app.add_css_file("docsearch.css", priority=150)
+    if app.config.html_awesome_docsearch:
+        app.add_css_file("docsearch.css", priority=150)
+
     app.connect("html-page-context", setup_docsearch)
 
     return {


### PR DESCRIPTION
The HTML templates expect `docsearch_config` to be present in the
context. This commit handles the inclusion/exclusion of assets
correctly, depending on whether DocSearch is used or not.
