### PR TITLE
docs: fix meta description tag

### DIFF
--- a/docs/how-to/install.md
+++ b/docs/how-to/install.md
@@ -1,5 +1,5 @@
 ---
-html_theme:
+html_meta:
   description: |
     Learn how to install the Awesome Theme for your documentation project.
 ---

--- a/docs/how-to/install.md
+++ b/docs/how-to/install.md
@@ -40,7 +40,7 @@ pip install git+https://github.com/kai687/sphinxawesome-theme.git
 
 <!-- vale 18F.UnexpandedAcronyms = NO -->
 
-See the {gh}`CHANGELOG <CHANGELOG.rst>` file for extra features and updates in the
+See the {gh}`CHANGELOG <CHANGELOG.md>` file for extra features and updates in the
 development version that aren't released yet.
 
 <!-- vale 18F.UnexpandedAcronyms = YES -->

--- a/docs/how-to/load.md
+++ b/docs/how-to/load.md
@@ -1,5 +1,5 @@
 ---
-html_theme:
+html_meta:
   description: |
     Learn how to add the Awesome Theme to your Sphinx documentation.
 ---

--- a/docs/how-to/modify.md
+++ b/docs/how-to/modify.md
@@ -1,5 +1,5 @@
 ---
-html_theme:
+html_meta:
   description: |
     Make your own theme by building on top of this theme.
     Fully customize the styles, JavaScript, and templates.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,5 @@
 ---
 html_meta:
-  title: The Awesome Sphinx Theme
   description: Create functional and beautiful websites for your documentation with Sphinx and the Awesome Sphinx Theme.
   keywords: Documentation, Sphinx, Python
 ---


### PR DESCRIPTION
All Markdown pages should use `html_meta` now.
I accidentally used `html_theme` on a few pages.