### PR TITLE
chore: ignore ANN401

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,6 +1,6 @@
 [flake8]
 select = ANN,BLK,B,B89,B9,C,D,E,F,S,W,ISC
-ignore = E203, ANN101
+ignore = E203, ANN101, ANN401
 extend-ignore = W203, W503
 max-complexity = 10
 max-line-length = 88


### PR DESCRIPTION
This rule flags type `Any` as errors. In some cases, I'm using docutils functions, that return `Any`, in other cases, I don't know what the type is from Sphinx, so I won't bother for now.