### PR TITLE
fix: theme works without setting extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## HEAD
+
+- Theme no longer breaks when not setting it as extension (#1042)
+
 ## 3.3.1
 
 - Handle DocSearch inclusion correctly (#781)

--- a/README.md
+++ b/README.md
@@ -31,14 +31,21 @@ Sphinx configuration.
    html_theme = "sphinxawesome_theme"
    ```
 
+1. Add the theme as an extension in the Sphinx configuration file `conf.py`:
+
+   ```python
+   extensions = ["sphinxawesome_theme"]
+   ```
+
    See [How to load the theme](https://sphinxawesome.xyz/how-to/load/) for more information.
 
-For more information about configuring the theme to your use case, see [How to configure the theme](https://sphinxawesome.xyz/how-to/options/).
+For more information about configuring the theme for your use case,
+see [How to configure the theme](https://sphinxawesome.xyz/how-to/options/).
 
 ## Features
 
 With the Awesome Theme, you can build readable, functional, and beautiful documentation websites.
-Compared to other Sphinx themes, these features enhance the user experience:
+These features enhance the user experience:
 
 ### Awesome code blocks
 
@@ -67,7 +74,7 @@ Clicking the link icon after a header or caption automatically copies the URL to
 ### DocSearch
 
 If you have an Algolia DocSearch account for your documentation (it's free for open-source projects),
-you can use DocSearch for a search-as-you-type experience with autocomplete. 
+you can use DocSearch for a search-as-you-type experience with autocomplete.
 
 ### Better keyboard navigation
 

--- a/docs/how-to/load.md
+++ b/docs/how-to/load.md
@@ -22,15 +22,26 @@ backlinks: none
 
 ## Load the theme from a Python package
 
-If you installed the {{ product }} {ref}`as a Python package <sec:install-python-package>`,
-add the `html_theme` configuration option to your Sphinx configuration file `conf.py`:
+To use the {{ product }} in your documentation:
 
-```{code-block} python
----
-caption: "File: conf.py"
----
-html_theme = "sphinxawesome_theme"
-```
+1. {ref}`sec:install-python-package`
+1. Add the `html_theme` configuration option to your Sphinx configuration file `conf.py`:
+
+    ```{code-block} python
+    ---
+    caption: "File: conf.py"
+    ---
+    html_theme = "sphinxawesome_theme"
+    ```
+
+1. Add the `sphinxawesome_theme` as an extension to your Sphinx configuration:
+
+   ```{code-block} python
+   ---
+   caption: "File: conf.py"
+   ---
+   extensions = ["sphinxawesome_theme"]
+   ```
 
 ## Load the theme from a local directory
 

--- a/src/sphinxawesome_theme/static/docsearch_config.js_t
+++ b/src/sphinxawesome_theme/static/docsearch_config.js_t
@@ -1,6 +1,8 @@
+{% if docsearch_config %}
 docsearch({
   container: "{{ docsearch_config.container|default('#docsearch') }}",
   appId: "{{ docsearch_config.app_id }}",
   apiKey: "{{ docsearch_config.api_key }}",
   indexName: "{{ docsearch_config.index_name }}",
 });
+{% endif %}


### PR DESCRIPTION
Just copy an empty `docsearch_config.js` file
when the theme isn't loaded as an extension.

Close #797 