### PR TITLE
fix: docsearch

### DIFF
--- a/src/sphinxawesome_theme/static/docsearch_config.js_t
+++ b/src/sphinxawesome_theme/static/docsearch_config.js_t
@@ -1,8 +1,8 @@
-{% if docsearch %}
+{%- if docsearch_config %}
 docsearch({
   container: "{{ docsearch_config.container|default('#docsearch') }}",
   appId: "{{ docsearch_config.app_id }}",
   apiKey: "{{ docsearch_config.api_key }}",
   indexName: "{{ docsearch_config.index_name }}",
 });
-{% endif %}
+{%- endif %}


### PR DESCRIPTION
This PR fixes a bug introduced in #1048: `docsearch` is only available in the HTML templates, not in the JavaScript templates.