### PR TITLE
fix: docsearch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.3.4
+
+- Fix bug introduced #1048 with DocSearch
+
 ## 3.3.3
 
 - Re-apply #1045 (overwrote changes by accident)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sphinxawesome-theme"
-version = "3.3.3"
+version = "3.3.4"
 description = "An awesome theme for the Sphinx documentation generator"
 readme = "README.md"
 authors = ["Kai Welke <kai687@pm.me>"]

--- a/tests/test_sphinxawesome_theme.py
+++ b/tests/test_sphinxawesome_theme.py
@@ -10,7 +10,7 @@ import sphinxawesome_theme
 
 def test_returns_version() -> None:
     """It has the correct version."""
-    assert sphinxawesome_theme.__version__ == "3.3.3"
+    assert sphinxawesome_theme.__version__ == "3.3.4"
 
 
 @pytest.mark.sphinx("dummy")


### PR DESCRIPTION
`docsearch` isn't available in the `docsearch_config.js_t` template. 