### PR TITLE
fix: restore logo in header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 4.0.2
+
+- Restore missing logo (#1214)
+
 ## 4.0.1
 
 - Fix a layout issue introduced by MyST parser 0.19.1 (#1212)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sphinxawesome-theme"
-version = "4.0.1"
+version = "4.0.2"
 description = "An awesome theme for the Sphinx documentation generator"
 readme = "README.md"
 authors = ["Kai Welke <kai687@pm.me>"]

--- a/src/sphinxawesome_theme/header.html
+++ b/src/sphinxawesome_theme/header.html
@@ -16,8 +16,10 @@
 <a class="hover:bg-gray-700 focus:bg-gray-700 focus:outline-none"
    href="{{ pathto(master_doc) }}"
    title="{{ _('Back to homepage') }}">
-  {%- if logo -%}
-    <img class="h-14 w-14 p-3 inline-block" src="{{ pathto('_static/' + logo, 1) }}" alt="Logo" />
+
+  {%- set _logo_url = logo_url|default(pathto('_static/' + (logo or ""), 1)) %}
+  {%- if logo or logo_url %}
+    <img class="h-14 w-14 p-3 inline-block" src="{{ _logo_url }}" alt="Logo" />
   {%- endif -%}
   <span class="hidden lg:inline-block shrink-0 font-medium text-gray-100 mx-5 leading-14 tracking-wider">{{ docstitle }}</span>
 </a>

--- a/src/sphinxawesome_theme/layout.html
+++ b/src/sphinxawesome_theme/layout.html
@@ -42,7 +42,7 @@
     {%- endif %}
     {%- set _favicon_url = favicon_url | default(pathto('_static/' + (favicon or ""), 1)) %}
     {%- if favicon_url or favicon %}
-    <link rel="shortcut icon" href="{{ _favicon_url }}"/>
+    <link rel="icon" href="{{ _favicon_url }}"/>
     {%- endif %}
     {%- block linktags %}
     {%- if hasdoc('search') and not docsearch %}

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -10,7 +10,7 @@ from sphinx.application import Sphinx
 
 def test_returns_version() -> None:
     """It has the correct version."""
-    assert sphinxawesome_theme.__version__ == "4.0.1"
+    assert sphinxawesome_theme.__version__ == "4.0.2"
 
 
 @pytest.mark.sphinx("dummy")


### PR DESCRIPTION
The Sphinx 6 update also removed `logo` in favor of `logo_url`.
This PR will make the theme work with both. Fixes #1214 