### PR TITLE
fix: better override for page.html

### DIFF
--- a/docs/_templates/page.html
+++ b/docs/_templates/page.html
@@ -1,17 +1,7 @@
-{% if meta and meta.layout %}
-  {%- extends meta.layout + ".html"|default("with-sidebar.html") -%}
-{% else %}
-  {% if theme_show_nav|tobool %}
-    {%- extends "with-sidebar.html" -%}
-  {% else %}
-    {%- extends "without-sidebar.html" -%}
-  {% endif %}
-{% endif %}
+{% extends "!page.html" %}
+
+{{ super() }}
 
 {% block extrahead %}
 <script async src="https://sphinxawesome.up.railway.app/script.js" data-website-id="5e3ad354-ab2b-4914-94f4-e390005d2389"></script>
-{% endblock %}
-
-{% block body %}
-  {{ body }}
 {% endblock %}


### PR DESCRIPTION
Just learned about the `extends "!template"` syntax for Jinja, which means I can just _extend_ the template without copying it.