### PR TITLE
refactor(highlighting): Make AwesomeCodeBlock directive shorter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,7 @@ sphinxawesome_theme = "sphinxawesome_theme"
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-tag_format = "$version"
+tag_format = "$major.$minor.$patch$prerelease"
 version_type = "semver"
 version_provider = "poetry"
 update_changelog_on_bump = true

--- a/src/sphinxawesome_theme/highlighting.py
+++ b/src/sphinxawesome_theme/highlighting.py
@@ -245,11 +245,12 @@ class AwesomeCodeBlock(CodeBlock):
         document = self.state.document
         location = self.state_machine.get_source_and_line(self.lineno)
         nlines = len(self.content)
+        linespec = self.options.get(option)
 
-        def _get_parsed_line_numbers(
-            linespec: str, nlines: int, location: str
-        ) -> list[int]:
-            """Get the parsed line numbers."""
+        if not linespec:
+            return None
+
+        try:
             line_numbers = parselinenos(linespec, nlines)
             if any(i >= nlines for i in line_numbers):
                 logger.warning(
@@ -257,14 +258,9 @@ class AwesomeCodeBlock(CodeBlock):
                     % (nlines, linespec),
                     location=location,
                 )
-            return [x + 1 for x in line_numbers if x < nlines]
-
-        linespec = self.options.get(option)
-        if linespec:
-            try:
-                return _get_parsed_line_numbers(linespec, nlines, location)
-            except ValueError as err:
-                return [document.reporter.warning(err, line=self.lineno)]
+            return [i + 1 for i in line_numbers if i < nlines]
+        except ValueError as err:
+            return [document.reporter.warning(err, line=self.lineno)]
 
     def run(self: AwesomeCodeBlock) -> list[Node]:
         """Handle parsing extra options for highlighting."""

--- a/src/sphinxawesome_theme/highlighting.py
+++ b/src/sphinxawesome_theme/highlighting.py
@@ -264,12 +264,12 @@ class AwesomeCodeBlock(CodeBlock):
 
     def run(self: AwesomeCodeBlock) -> list[Node]:
         """Handle parsing extra options for highlighting."""
-        # either `[code-block]`, or `[caption, code_block]`
         literal_nodes = super().run()
 
         hl_added = self._get_line_numbers("emphasize-added")
         hl_removed = self._get_line_numbers("emphasize-removed")
 
+        # `literal_nodes` is either `[literal_block]`, or `[caption, literal_block]`
         for node in literal_nodes:
             if isinstance(node, nodes.literal_block):
                 extra_args = node.get("highlight_args", {})


### PR DESCRIPTION
Instead of copying the complete directive, this commit makes use of inheritance and adds the additional options after running the parent.