### PR TITLE
feat: export permalinks icon

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -9,6 +9,7 @@ from sphinx.application import Sphinx
 from sphinx.util.docfields import Field
 from sphinxawesome_theme import ThemeOptions, __version__
 from sphinxawesome_theme.docsearch import DocSearchConfig
+from sphinxawesome_theme.postprocess import Icons
 
 load_dotenv()
 
@@ -74,17 +75,7 @@ html_domain_indices = False  # Don't need module indices
 html_copy_source = False  # Don't need sources
 html_logo = "assets/auto_awesome.svg"
 html_favicon = "assets/favicon-128x128.png"
-html_permalinks_icon = (
-    '<svg xmlns="http://www.w3.org/2000/svg" '
-    'height="1em" width="1em" '
-    'viewBox="0 0 24 24">'
-    '<path d="M3.9 12c0-1.71 1.39-3.1 '
-    "3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 "
-    "5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 "
-    "13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 "
-    "3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 "
-    '5-5s-2.24-5-5-5z"/></svg>'
-)
+html_permalinks_icon = Icons.permalinks_icon
 html_baseurl = "https://sphinxawesome.xyz/"
 html_extra_path = ["robots.txt", "_redirects"]
 html_context = {

--- a/src/sphinxawesome_theme/postprocess.py
+++ b/src/sphinxawesome_theme/postprocess.py
@@ -38,6 +38,7 @@ class Icons:
 
     external_link: str = '<svg xmlns="http://www.w3.org/2000/svg" height="1em" width="1em" fill="currentColor" stroke="none" viewBox="0 96 960 960"><path d="M188 868q-11-11-11-28t11-28l436-436H400q-17 0-28.5-11.5T360 336q0-17 11.5-28.5T400 296h320q17 0 28.5 11.5T760 336v320q0 17-11.5 28.5T720 696q-17 0-28.5-11.5T680 656V432L244 868q-11 11-28 11t-28-11Z"/></svg>'
     chevron_right: str = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="18px" height="18px" stroke="none" fill="currentColor"><path d="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"/></svg>'
+    permalinks_icon: str = '<svg xmlns="http://www.w3.org/2000/svg" height="1em" width="1em" viewBox="0 0 24 24"><path d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z"/></svg>'
 
 
 def _get_html_files(outdir: str) -> list[str]:


### PR DESCRIPTION
Instead of copying and pasting SVG code for the permalink icon, export it as part of the `Icons` class.