### PR TITLE
fix: pin Sphinx version

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -540,13 +540,13 @@ files = [
 
 [[package]]
 name = "docutils"
-version = "0.20.1"
+version = "0.19"
 description = "Docutils -- Python Documentation Utilities"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "docutils-0.20.1-py3-none-any.whl", hash = "sha256:96f387a2c5562db4476f09f13bbab2192e764cac08ebbf3a34a95d9b1e4a59d6"},
-    {file = "docutils-0.20.1.tar.gz", hash = "sha256:f08a4e276c3a1583a86dce3e34aba3fe04d02bba2dd51ed16106244e8a923e3b"},
+    {file = "docutils-0.19-py3-none-any.whl", hash = "sha256:5e1de4d849fee02c63b040a4a3fd567f4ab104defd8a5511fbbc24a8a017efbc"},
+    {file = "docutils-0.19.tar.gz", hash = "sha256:33995a6753c30b7f577febfc2c50411fec6aac7f7ffeb7c4cfe5991072dcf9e6"},
 ]
 
 [[package]]
@@ -1737,20 +1737,20 @@ files = [
 
 [[package]]
 name = "sphinx"
-version = "7.1.2"
+version = "6.2.1"
 description = "Python documentation generator"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "sphinx-7.1.2-py3-none-any.whl", hash = "sha256:d170a81825b2fcacb6dfd5a0d7f578a053e45d3f2b153fecc948c37344eb4cbe"},
-    {file = "sphinx-7.1.2.tar.gz", hash = "sha256:780f4d32f1d7d1126576e0e5ecc19dc32ab76cd24e950228dcf7b1f6d3d9e22f"},
+    {file = "Sphinx-6.2.1.tar.gz", hash = "sha256:6d56a34697bb749ffa0152feafc4b19836c755d90a7c59b72bc7dfd371b9cc6b"},
+    {file = "sphinx-6.2.1-py3-none-any.whl", hash = "sha256:97787ff1fa3256a3eef9eda523a63dbf299f7b47e053cfcf684a1c2a8380c912"},
 ]
 
 [package.dependencies]
 alabaster = ">=0.7,<0.8"
 babel = ">=2.9"
 colorama = {version = ">=0.4.5", markers = "sys_platform == \"win32\""}
-docutils = ">=0.18.1,<0.21"
+docutils = ">=0.18.1,<0.20"
 imagesize = ">=1.3"
 importlib-metadata = {version = ">=4.8", markers = "python_version < \"3.10\""}
 Jinja2 = ">=3.0"
@@ -2143,4 +2143,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "7d4ce6af83c20684d9ff8938a78b55bf3c83a48af6b2d8df9367a07e2950e667"
+content-hash = "0b61477559e705b0b221dd51c9b34cc8fd50a2dfd1c9701732bc787ad3dad4d2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sphinxawesome-theme"
-version = "5.0.0-beta.4"
+version = "5.0.0-beta.5"
 description = "An awesome theme for the Sphinx documentation generator"
 readme = "README.md"
 authors = ["Kai Welke <kai687@pm.me>"]
@@ -22,7 +22,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = "^3.8"
-sphinx = ">4, <7.2"
+sphinx = ">4, <7"
 beautifulsoup4 = "^4.9.1"
 
 [tool.poetry.group.docs.dependencies]

--- a/src/theme-src/package.json
+++ b/src/theme-src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sphinxawesome-theme",
-  "version": "5.0.0-beta.4",
+  "version": "5.0.0-beta.5",
   "scripts": {
     "build": "NODE_ENV=production webpack",
     "dev": "NODE_ENV=development webpack --watch --progress",

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -10,7 +10,7 @@ from sphinx.application import Sphinx
 
 def test_returns_version() -> None:
     """It has the correct version."""
-    assert sphinxawesome_theme.__version__ == "5.0.0b4"
+    assert sphinxawesome_theme.__version__ == "5.0.0b5"
 
 
 @pytest.mark.sphinx("dummy")


### PR DESCRIPTION
In Sphinx 7, copying the static assets happens BEFORE the `doctree-resolved` event is emitted.
Because we update the globalcontext with the DocSearch configuration when handling this event, the `docsearch_config.js` file ends up empty. DocSearch is NOT being added. 

In Sphinx 6, copying the static files happens AFTER the `doctree-resolved` event is emitted.
The global context has the DocSearch configuration, the `docsearch_config.js` file is NOT empty, and DocSearch works as expected.

Properly supporting the latest version of Sphinx is a bit of a challenge due to the many expected and unexpected changes. Until I figure it out, I won't support Sphinx 7.