### PR TITLE
Fix a typo in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
 
    ```python
    # conf.py
-   extensions += ["sphinxawesome.highlighting"]
+   extensions += ["sphinxawesome_theme.highlighting"]
    ```
 
 ## Features


### PR DESCRIPTION
The docs say sphinxawesome_theme.highlighting plus I get an error when trying just sphinxawesome.highlighting (which makes sense).