### PR TITLE
docs: correct content blocks

### DIFF
--- a/docs/how-to/customize/includes/extend-template-blocks.rst
+++ b/docs/how-to/customize/includes/extend-template-blocks.rst
@@ -7,8 +7,11 @@ To add code, you can :ref:`extend the page template <sec:extend-templates>` and 
    Adds your template code before the closing ``</head>`` tag.
    This is useful to add custom styles or JavaScript code.
 
-``extrabody``
-   Adds extra code **after** the main content, before the footer.
+``body_before``
+   Adds content to the top of the page.
+
+``body_after``
+   Adds content to the bottom of the page.
 
 .. code-block:: html+jinja
    :caption: File: page.html


### PR DESCRIPTION
Updates documentation about the overrideable template blocks in the page layouts.

Closes #1706 