### PR TITLE
fix: supported python version

### DIFF
--- a/docs/readthedocs.txt
+++ b/docs/readthedocs.txt
@@ -6,7 +6,7 @@ beautifulsoup4==4.12.3 ; python_version >= "3.8" and python_version < "4.0"
 certifi==2024.2.2 ; python_version >= "3.8" and python_version < "4.0"
 charset-normalizer==3.3.2 ; python_version >= "3.8" and python_version < "4.0"
 click==8.1.7 ; python_version >= "3.9" and python_full_version <= "3.12.0"
-colorama==0.4.6 ; python_version >= "3.8" and python_version < "4.0" and (python_full_version <= "3.12.0" or sys_platform == "win32")
+colorama==0.4.6 ; python_version >= "3.8" and python_version < "4.0" and (sys_platform == "win32" or python_full_version <= "3.12.0")
 docutils==0.20.1 ; python_version >= "3.8" and python_version < "4.0"
 exceptiongroup==1.2.0 ; python_version >= "3.9" and python_version < "3.11"
 h11==0.14.0 ; python_version >= "3.9" and python_full_version <= "3.12.0"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2482,4 +2482,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "5beb149585a3992740288bce8992e4f4aaa293a686ecbf4968ece0080f8b3c78"
+content-hash = "c2c34f7be8a3575d160408bf2bbdd95336e1423135e009dc12f9831c52a80568"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ packages = [
 python = "^3.8"
 sphinx = [
   { version = "<7.2", python = ">=3.8,<3.9"},
-  { version = "^7.2,<7.3", python = ">=3.9,<=3.12"},
+  { version = "^7.2,<7.3", python = ">=3.9,<3.13"},
 ]
 beautifulsoup4 = "^4.9.1"
 


### PR DESCRIPTION
On Python 3.12, Sphinx didn't get installed as a dependency because I didn't specify the dependency correctly.