### PR TITLE
fix: only track main domain

### DIFF
--- a/docs/_templates/page.html
+++ b/docs/_templates/page.html
@@ -6,7 +6,7 @@
 {# `mode` is injected via `html_context` in `conf.py` #}
 {# You can override it with `-A` at build time #}
 {%- if mode == "production" %}
-<script async src="https://sphinxawesome.up.railway.app/script.js" data-website-id="5e3ad354-ab2b-4914-94f4-e390005d2389"></script>
+<script async src="https://sphinxawesome.up.railway.app/script.js" data-website-id="5e3ad354-ab2b-4914-94f4-e390005d2389" data-domains="sphinxawesome.xyz"></script>
 {%- endif %}
 {%- endblock %}
 


### PR DESCRIPTION
If you clone everything, including the docs folder, and publish a website.
then any website has the tracking code which will show up in my analytics.

This is the first, easy step to prevent this (also helps with deployment previews).