### PR TITLE
Typo in code-blocks demo

### DIFF
--- a/docs/demo/code-blocks.rst
+++ b/docs/demo/code-blocks.rst
@@ -105,7 +105,7 @@ for highlighting added or removed lines of code:
    Highlight added lines with :samp:`:emphasize-added: {LINE_NUMBERS}`.
 
 ``:emphasize-removed:``
-   Highlight removed lines with :samp:`:emphasize-added: {LINE_NUMBERS}`.
+   Highlight removed lines with :samp:`:emphasize-removed: {LINE_NUMBERS}`.
 
 .. code-block:: rst
 


### PR DESCRIPTION
Swap emphasize-added to removed in description of the aforementioned command.

See bellow:
<img width="573" height="156" alt="typo_highlight" src="https://github.com/user-attachments/assets/d33d6fc9-1d13-4633-b552-005a72afe071" />
