### PR TITLE
chore: migrate typechecking to ty

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,13 +40,27 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm run ci
       - run: pnpm build
-  test:
-    name: Run CI workflows
+
+  quality:
+    name: Run lint and type checking
     runs-on: ubuntu-latest
-    needs:
-      - format
-      - theme
+    steps:
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v7
+        with:
+          version: "latest"
+          python-version: "3.14"
+          enable-cache: true
+      - name: Set up hatch
+        run: uv tool install hatch
+      - name: Run lint and type checking
+        run: hatch run lint:all
+
+  test:
+    name: Run tests
+    runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version:
           - "3.10"
@@ -60,8 +74,6 @@ jobs:
           enable-cache: true
       - name: Set up hatch
         run: uv tool install hatch
-      - name: Run lint and type checking
-        run: hatch run lint:all
       - name: Run test workflow
         run: hatch run test.py${{ matrix.python-version }}:run
         env:
@@ -71,9 +83,6 @@ jobs:
   docs:
     name: Build the docs (for testing)
     runs-on: ubuntu-latest
-    needs:
-      - format
-      - theme
     steps:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v7
@@ -96,6 +105,7 @@ jobs:
     needs:
       - format
       - theme
+      - quality
       - test
       - docs
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,8 +60,10 @@ jobs:
           enable-cache: true
       - name: Set up hatch
         run: uv tool install hatch
-      - name: Run dev workflow
-        run: hatch run dev:all
+      - name: Run lint and type checking
+        run: hatch run lint:all
+      - name: Run test workflow
+        run: hatch run test.py${{ matrix.python-version }}:run
         env:
           DOCSEARCH_APP_ID: ${{ vars.DOCSEARCH_APP_ID }}
           DOCSEARCH_API_KEY: ${{ vars.DOCSEARCH_API_KEY }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,14 +80,22 @@ build = "sphinx-build -b dirhtml -aWTE docs docs/public"
 live = "sphinx-autobuild -q -b dirhtml -A mode='development' -aTE docs docs/public --ignore docs/jupyter_execute --ignore docs/public"
 links = "sphinx-build -b linkcheck -aWTE docs docs/public/_links"
 
-[tool.hatch.envs.dev]
+[tool.hatch.envs.lint]
 dependency-groups = ["docs", "dev"]
 
-[tool.hatch.envs.dev.scripts]
-test = "pytest --cov"
+[tool.hatch.envs.lint.scripts]
 lint = "ruff check ."
 typecheck = "ty check"
-all = ["test", "lint", "typecheck"]
+all = ["lint", "typecheck"]
+
+[tool.hatch.envs.test]
+dependency-groups = ["docs", "dev"]
+
+[tool.hatch.envs.test.scripts]
+run = "pytest --cov"
+
+[[tool.hatch.envs.test.matrix]]
+python = ["3.10", "3.14"]
 
 [tool.hatch.envs.hatch-static-analysis]
 config-path = "none"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,16 +37,16 @@ sphinxawesome_theme = "sphinxawesome_theme"
 [dependency-groups]
 dev = [
   "coverage[toml]",
-  "pyright",
   "pytest",
   "pytest-cov",
   "ruff",
+  "ty>=0.0.26",
   "types-beautifulsoup4",
   "types-docutils",
   "types-pygments",
 ]
 docs = [
-  "myst-nb",
+  "myst-nb>=1.4.0",
   "python-dotenv",
   "sphinx-autoapi",
   "sphinx-autobuild",
@@ -86,15 +86,17 @@ dependency-groups = ["docs", "dev"]
 [tool.hatch.envs.dev.scripts]
 test = "pytest --cov"
 lint = "ruff check ."
-typecheck = "pyright"
+typecheck = "ty check"
 all = ["test", "lint", "typecheck"]
 
 [tool.hatch.envs.hatch-static-analysis]
 config-path = "none"
 
-[tool.pyright]
-include = ["src"]
-reportUnnecessaryTypeIgnoreComment = "warning"
+[tool.ty.rules]
+unused-ignore-comment = "warn"
+
+[tool.ty.src]
+include = ["src", "tests"]
 
 [tool.ruff.lint]
 # TODO: Check if all of these even make sense

--- a/src/sphinxawesome_theme/code.py
+++ b/src/sphinxawesome_theme/code.py
@@ -12,14 +12,14 @@ New options:
 
 from __future__ import annotations
 
-from typing import Literal
+from typing import Literal, cast
 
 from docutils import nodes
 from docutils.nodes import Node, system_message
 from docutils.parsers.rst import directives
 from sphinx.directives.code import CodeBlock
 from sphinx.locale import __
-from sphinx.util import logging, parselinenos  # type: ignore
+from sphinx.util import logging, parselinenos
 
 logger = logging.getLogger(__name__)
 
@@ -74,19 +74,24 @@ class AwesomeCodeBlock(CodeBlock):
 
     def _extra_args(
         self: AwesomeCodeBlock,
-        node: Node,
+        node: nodes.literal_block,
         hl_added: list[int] | list[system_message] | None,
         hl_removed: list[int] | list[system_message] | None,
     ) -> None:
         """Set extra attributes for line highlighting."""
-        extra_args = node.get("highlight_args", {})  # type: ignore[attr-defined]
+        extra_args = node.get("highlight_args")
+        if not isinstance(extra_args, dict):
+            extra_args = {}
+            node["highlight_args"] = extra_args
+
+        highlight_args = cast(dict[str, object], extra_args)
 
         if hl_added is not None:
-            extra_args["hl_added"] = hl_added
+            highlight_args["hl_added"] = hl_added
         if hl_removed is not None:
-            extra_args["hl_removed"] = hl_removed
+            highlight_args["hl_removed"] = hl_removed
         if "emphasize-text" in self.options:
-            extra_args["hl_text"] = self.options["emphasize-text"]
+            highlight_args["hl_text"] = self.options["emphasize-text"]
 
     def run(self: AwesomeCodeBlock) -> list[Node]:
         """Handle parsing extra options for highlighting."""

--- a/src/sphinxawesome_theme/logos.py
+++ b/src/sphinxawesome_theme/logos.py
@@ -23,11 +23,12 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 from docutils.nodes import Node
 from sphinx.application import Sphinx
-from sphinx.util import isurl, logging  # type: ignore
+from sphinx.builders.html import StandaloneHTMLBuilder
+from sphinx.util import isurl, logging
 from sphinx.util.fileutil import copy_asset_file
 
 logger = logging.getLogger(__name__)
@@ -39,8 +40,9 @@ def get_theme_options(app: Sphinx) -> Any:
     Adapted from the ``pydata_sphinx_theme``.
     https://github.com/pydata/pydata-sphinx-theme/blob/f15ecfed59a2a5096c05496a3d817fef4ef9a0af/src/pydata_sphinx_theme/utils.py
     """
-    if hasattr(app.builder, "theme_options"):
-        return app.builder.theme_options  # type:ignore
+    builder = app.builder
+    if isinstance(builder, StandaloneHTMLBuilder):
+        return cast(dict[str, Any], builder.theme_options)
     elif hasattr(app.config, "html_theme_options"):
         return app.config.html_theme_options
     else:

--- a/src/sphinxawesome_theme/postprocess.py
+++ b/src/sphinxawesome_theme/postprocess.py
@@ -23,13 +23,21 @@ from __future__ import annotations
 import os
 import pathlib
 from dataclasses import dataclass
+from typing import cast
 
 from bs4 import BeautifulSoup, Comment
 from sphinx.application import Sphinx
+from sphinx.builders.html import StandaloneHTMLBuilder
 from sphinx.environment import BuildEnvironment
 from sphinx.util.display import status_iterator
 
 from . import logos
+
+
+class AwesomeBuildEnvironment(BuildEnvironment):
+    """Build environment with tracked changed documents."""
+
+    awesome_changed_docs: list[str]
 
 
 @dataclass(frozen=True)
@@ -49,7 +57,9 @@ def changed_docs(app: Sphinx, env: BuildEnvironment, docnames: list[str]) -> Non
 
     This is useful to make sure postprocessing only runs on changed files.
     """
-    app.env.awesome_changed_docs = docnames  # type:ignore
+    del env
+    awesome_env = cast(AwesomeBuildEnvironment, app.env)
+    awesome_env.awesome_changed_docs = docnames
 
 
 def get_html_files(outdir: pathlib.Path | str) -> list[str]:
@@ -162,7 +172,7 @@ def strip_comments(tree: BeautifulSoup) -> None:
         c.extract()
 
 
-def modify_html(html_filename: str, app: Sphinx) -> None:
+def modify_html(html_filename: os.PathLike[str] | str, app: Sphinx) -> None:
     """Modify a single HTML document.
 
     1. The HTML document is parsed into a BeautifulSoup tree.
@@ -202,9 +212,11 @@ def post_process_html(app: Sphinx, exc: Exception | None) -> None:
     if app.builder is not None and app.builder.name not in ["html", "dirhtml"]:
         return
 
+    builder = cast(StandaloneHTMLBuilder, app.builder)
+    env = cast(AwesomeBuildEnvironment, app.env)
+
     files_to_postprocess = [
-        app.builder.get_outfilename(doc)  # type: ignore[attr-defined]
-        for doc in app.env.awesome_changed_docs  # type: ignore[attr-defined]
+        builder.get_outfilename(doc) for doc in env.awesome_changed_docs
     ]
 
     if len(files_to_postprocess) == 0:

--- a/src/sphinxawesome_theme/toc.py
+++ b/src/sphinxawesome_theme/toc.py
@@ -11,6 +11,7 @@ from typing import Any
 from docutils import nodes
 from docutils.nodes import Node
 from sphinx.application import Sphinx
+from sphinx.builders.html import StandaloneHTMLBuilder
 from sphinx.environment.adapters.toctree import TocTree
 from sphinx.util.docutils import new_document
 
@@ -46,7 +47,11 @@ def change_toc(
 
     Then, we _outdent_ the tree.
     """
-    toc = TocTree(app.builder.env).get_toc_for(pagename, app.builder)
+    builder = app.builder
+    if not isinstance(builder, StandaloneHTMLBuilder):
+        return
+
+    toc = TocTree(builder.env).get_toc_for(pagename, builder)
 
     # Remove `h1` node
     for node in toc.findall(nodes.reference):
@@ -70,4 +75,4 @@ def change_toc(
     toc_root = doc.children[0] if doc.children else None
 
     # Use the public builder API to render the doctree fragment.
-    context["toc"] = app.builder.render_partial(toc_root)["fragment"]  # type: ignore[attr-defined]
+    context["toc"] = builder.render_partial(toc_root)["fragment"]

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -27,8 +27,8 @@ def test_awesome_sphinx_design(app: Sphinx) -> None:
     # It adds the `awesome-sphinx-design.css` file
     css = tree.select('link[rel="stylesheet"]')
     assert len(css) == 4
-    hrefs = [item["href"] for item in css]
-    assert any(filter(pattern.search, hrefs))  # type: ignore[arg-type]
+    hrefs = [str(item["href"]) for item in css]
+    assert any(pattern.search(href) is not None for href in hrefs)
 
 
 @pytest.mark.sphinx(
@@ -48,5 +48,5 @@ def test_awesome_myst_nb(app: Sphinx) -> None:
     # It adds the `awesome-myst-nb.css` file
     css = tree.select('link[rel="stylesheet"]')
     assert len(css) == 4
-    hrefs = [item["href"] for item in css]
-    assert any(filter(pattern.search, hrefs))  # type: ignore[arg-type]
+    hrefs = [str(item["href"]) for item in css]
+    assert any(pattern.search(href) is not None for href in hrefs)

--- a/tests/test_external_links.py
+++ b/tests/test_external_links.py
@@ -1,6 +1,7 @@
 """Test the construction of canonical links."""
 
 from pathlib import Path
+from typing import cast
 
 import pytest
 from sphinx.application import Sphinx
@@ -41,9 +42,9 @@ def test_no_external_link_icons(app: Sphinx) -> None:
 def test_external_link_icons(app: Sphinx) -> None:
     """It adds an external link icon to external references."""
     app.build()
-    if hasattr(app.builder, "theme_options"):
-        assert "awesome_external_links" in app.builder.theme_options
-        assert app.builder.theme_options["awesome_external_links"] is True
+    theme_options = cast(dict[str, object], getattr(app.builder, "theme_options", {}))
+    assert "awesome_external_links" in theme_options
+    assert theme_options["awesome_external_links"] is True
 
     tree = parse_html(Path(app.outdir) / "index.html")
 

--- a/tests/test_logos.py
+++ b/tests/test_logos.py
@@ -20,7 +20,7 @@ def test_no_logo(app: Sphinx, warning: StringIO) -> None:
     """It compiles without defining a logo."""
     app.build()
     tree = parse_html(Path(app.outdir) / "index.html")
-    logos = tree.select("header img", attrs={"alt": "Logo"})
+    logos = tree.select('header img[alt="Logo"]')
     assert len(logos) == 0
 
     warnings = warning.getvalue()
@@ -39,7 +39,7 @@ def test_default_logo(app: Sphinx, warning: StringIO) -> None:
     """It compiles without ``logo_light`` and ``logo_dark``."""
     app.build()
     tree = parse_html(Path(app.outdir) / "index.html")
-    logos = tree.select("header img", attrs={"alt": "Logo"})
+    logos = tree.select('header img[alt="Logo"]')
     assert len(logos) == 1
 
     warnings = warning.getvalue()
@@ -59,10 +59,10 @@ def test_includes_only_one_html_logo(app: Sphinx, warning: StringIO) -> None:
     """It includes a single logo if both `logo_light` and `html_logo` are defined."""
     app.build()
     tree = parse_html(Path(app.outdir) / "index.html")
-    logos = tree.select("header img", alt="Logo")
+    logos = tree.select('header img[alt="Logo"]')
     assert len(logos) == 1
 
-    sidebar = tree.select("#left-sidebar img", alt="Logo")
+    sidebar = tree.select('#left-sidebar img[alt="Logo"]')
     assert len(sidebar) == 1
 
     warnings = warning.getvalue()
@@ -129,8 +129,8 @@ def test_copies_logos(app: Sphinx, warning: StringIO) -> None:
     assert dark.exists()
 
     tree = parse_html(Path(app.outdir) / "index.html")
-    logos = tree.select("header img", alt="Logo")
+    logos = tree.select('header img[alt="Logo"]')
     assert len(logos) == 2
 
-    sidebar = tree.select("#left-sidebar img", alt="Logo")
+    sidebar = tree.select('#left-sidebar img[alt="Logo"]')
     assert len(sidebar) == 2

--- a/uv.lock
+++ b/uv.lock
@@ -1872,6 +1872,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "ruff" },
+    { name = "ty" },
     { name = "types-beautifulsoup4" },
     { name = "types-docutils" },
     { name = "types-pygments" },
@@ -1901,6 +1902,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "ruff" },
+    { name = "ty", specifier = ">=0.0.26" },
     { name = "types-beautifulsoup4" },
     { name = "types-docutils" },
     { name = "types-pygments" },
@@ -2143,6 +2145,30 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/eb/79/72064e6a701c2183016abbbfedaba506d81e30e232a68c9f0d6f6fcd1574/traitlets-5.14.3.tar.gz", hash = "sha256:9ed0579d3502c94b4b3732ac120375cda96f923114522847de4b3bb98b96b6b7", size = 161621, upload-time = "2024-04-19T11:11:49.746Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl", hash = "sha256:b74e89e397b1ed28cc831db7aea759ba6640cb3de13090ca145426688ff1ac4f", size = 85359, upload-time = "2024-04-19T11:11:46.763Z" },
+]
+
+[[package]]
+name = "ty"
+version = "0.0.26"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/18/94/4879b81f8681117ccaf31544579304f6dc2ddcc0c67f872afb35869643a2/ty-0.0.26.tar.gz", hash = "sha256:0496b62405d62de7b954d6d677dc1cc5d3046197215d7a0a7fef37745d7b6d29", size = 5393643, upload-time = "2026-03-26T16:27:11.067Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/24/99fe33ecd7e16d23c53b0d4244778c6d1b6eb1663b091236dcba22882d67/ty-0.0.26-py3-none-linux_armv6l.whl", hash = "sha256:35beaa56cf59725fd59ab35d8445bbd40b97fe76db39b052b1fcb31f9bf8adf7", size = 10521856, upload-time = "2026-03-26T16:27:06.335Z" },
+    { url = "https://files.pythonhosted.org/packages/55/97/1b5e939e2ff69b9bb279ab680bfa8f677d886309a1ac8d9588fd6ce58146/ty-0.0.26-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:487a0be58ab0eb02e31ba71eb6953812a0f88e50633469b0c0ce3fb795fe0fa1", size = 10320958, upload-time = "2026-03-26T16:27:13.849Z" },
+    { url = "https://files.pythonhosted.org/packages/71/25/37081461e13d38a190e5646948d7bc42084f7bd1c6b44f12550be3923e7e/ty-0.0.26-py3-none-macosx_11_0_arm64.whl", hash = "sha256:a01b7de5693379646d423b68f119719a1338a20017ba48a93eefaff1ee56f97b", size = 9799905, upload-time = "2026-03-26T16:26:55.805Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/1c/295d8f55a7b0e037dfc3a5ec4bdda3ab3cbca6f492f725bf269f96a4d841/ty-0.0.26-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:628c3ee869d113dd2bd249925662fd39d9d0305a6cb38f640ddaa7436b74a1ef", size = 10317507, upload-time = "2026-03-26T16:27:31.887Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/62/48b3875c5d2f48fe017468d4bbdde1164c76a8184374f1d5e6162cf7d9b8/ty-0.0.26-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:63d04f35f5370cbc91c0b9675dc83e0c53678125a7b629c9c95769e86f123e65", size = 10319821, upload-time = "2026-03-26T16:27:29.647Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/28/cfb2d495046d5bf42d532325cea7412fa1189912d549dbfae417a24fd794/ty-0.0.26-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4a53c4e6f6a91927f8b90e584a4b12bcde05b0c1870ddff8d17462168ad7947a", size = 10831757, upload-time = "2026-03-26T16:27:37.441Z" },
+    { url = "https://files.pythonhosted.org/packages/26/bf/dbc3e42f448a2d862651de070b4108028c543ca18cab096b38d7de449915/ty-0.0.26-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:caf2ced0e58d898d5e3ba5cb843e0ebd377c8a461464748586049afbd9321f51", size = 11369556, upload-time = "2026-03-26T16:26:58.655Z" },
+    { url = "https://files.pythonhosted.org/packages/92/4c/6d2f8f34bc6d502ab778c9345a4a936a72ae113de11329c1764bb1f204f6/ty-0.0.26-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:384807bbcb7d7ce9b97ee5aaa6417a8ae03ccfb426c52b08018ca62cf60f5430", size = 11085679, upload-time = "2026-03-26T16:27:21.746Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/f4/f3f61c203bc980dd9bba0ba7ed3c6e81ddfd36b286330f9487c2c7d041aa/ty-0.0.26-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8a2c766a94d79b4f82995d41229702caf2d76e5c440ec7e543d05c70e98bf8ab", size = 10900581, upload-time = "2026-03-26T16:27:24.39Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/fd/3ca1b4e4bdd129829e9ce78677e0f8e0f1038a7702dccecfa52f037c6046/ty-0.0.26-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:f41ac45a0f8e3e8e181508d863a0a62156341db0f624ffd004b97ee550a9de80", size = 10294401, upload-time = "2026-03-26T16:27:03.999Z" },
+    { url = "https://files.pythonhosted.org/packages/de/20/4ee3d8c3f90e008843795c765cb8bb245f188c23e5e5cc612c7697406fba/ty-0.0.26-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:73eb8327a34d529438dfe4db46796946c4e825167cbee434dc148569892e435f", size = 10351469, upload-time = "2026-03-26T16:27:19.003Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/b1/9fb154ade65906d4148f0b999c4a8257c2a34253cb72e15d84c1f04a064e/ty-0.0.26-py3-none-musllinux_1_2_i686.whl", hash = "sha256:4bb53a79259516535a1b55f613ba1619e9c666854946474ca8418c35a5c4fd60", size = 10529488, upload-time = "2026-03-26T16:27:01.378Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/70/9b02b03b1862e27b64143db65946d68b138160a5b6bfea193bee0b8bbc34/ty-0.0.26-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:2f0e75edc1aeb1b4b84af516c7891f631254a4ca3dcd15e848fa1e061e1fe9da", size = 10999015, upload-time = "2026-03-26T16:27:34.636Z" },
+    { url = "https://files.pythonhosted.org/packages/21/16/0a56b8667296e2989b9d48095472d98ebf57a0006c71f2a101bbc62a142d/ty-0.0.26-py3-none-win32.whl", hash = "sha256:943c998c5523ed6b519c899c0c39b26b4c751a9759e460fb964765a44cde226f", size = 9912378, upload-time = "2026-03-26T16:27:08.999Z" },
+    { url = "https://files.pythonhosted.org/packages/60/c2/fef0d4bba9cd89a82d725b3b1a66efb1b36629ecf0fb1d8e916cb75b8829/ty-0.0.26-py3-none-win_amd64.whl", hash = "sha256:19c856d343efeb1ecad8ee220848f5d2c424daf7b2feda357763ad3036e2172f", size = 10863737, upload-time = "2026-03-26T16:27:27.06Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/05/888ebcb3c4d3b6b72d5d3241fddd299142caa3c516e6d26a9cd887dfed3b/ty-0.0.26-py3-none-win_arm64.whl", hash = "sha256:2cde58ccffa046db1223dc28f3e7d4f2c7da8267e97cc5cd186af6fe85f1758a", size = 10285408, upload-time = "2026-03-26T16:27:16.432Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Migrate typechecking to `ty` and fix a bunch of type-related issues.